### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.27.2", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.26.3", default-features = false }
+rattler = { path="../rattler", version = "0.27.3", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.26.4", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.20.10", default-features = false }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.3", default-features = false, features = ["gateway"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.4", default-features = false, features = ["gateway"] }
 rattler_solve = { path="../rattler_solve", version = "1.0.0", default-features = false, features = ["resolvo", "libsolv_c"] }
 rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.0.0", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.1.4", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.1.5", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.3](https://github.com/mamba-org/rattler/compare/rattler-v0.27.2...rattler-v0.27.3) - 2024-07-25
+
+### Other
+- mark some crates 1.0 ([#789](https://github.com/mamba-org/rattler/pull/789))
+
 ## [0.27.2](https://github.com/mamba-org/rattler/compare/rattler-v0.27.1...rattler-v0.27.2) - 2024-07-23
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.27.2"
+version = "0.27.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.1.4", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.26.3", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.1.5", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.26.4", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.0", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.20.10", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.21.3", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.21.7", default-features = false, features = ["reqwest"] }
+rattler_shell = { path = "../rattler_shell", version = "0.21.4", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.21.8", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/mamba-org/rattler/compare/rattler_cache-v0.1.4...rattler_cache-v0.1.5) - 2024-07-25
+
+### Other
+- mark some crates 1.0 ([#789](https://github.com/mamba-org/rattler/pull/789))
+
 ## [0.1.4](https://github.com/mamba-org/rattler/compare/rattler_cache-v0.1.3...rattler_cache-v0.1.4) - 2024-07-23
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.1.4"
+version = "0.1.5"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -15,10 +15,10 @@ dirs.workspace = true
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.26.3", path = "../rattler_conda_types", default-features = false }
+rattler_conda_types = { version = "0.26.4", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.0", path = "../rattler_digest", default-features = false }
 rattler_networking = { version = "0.20.10", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.21.7", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_package_streaming = { version = "0.21.8", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.4](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.26.3...rattler_conda_types-v0.26.4) - 2024-07-25
+
+### Fixed
+- url parsing for namelessmatchspec and cleanup functions ([#790](https://github.com/mamba-org/rattler/pull/790))
+
+### Other
+- mark some crates 1.0 ([#789](https://github.com/mamba-org/rattler/pull/789))
+
 ## [0.26.3](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.26.2...rattler_conda_types-v0.26.3) - 2024-07-23
 
 ### Fixed

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.26.3"
+version = "0.26.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.22](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.21...rattler_index-v0.19.22) - 2024-07-25
+
+### Other
+- mark some crates 1.0 ([#789](https://github.com/mamba-org/rattler/pull/789))
+
 ## [0.19.21](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.20...rattler_index-v0.19.21) - 2024-07-23
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.21"
+version = "0.19.22"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.26.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.26.4", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.0", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.21.7", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.21.8", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.17](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.16...rattler_lock-v0.22.17) - 2024-07-25
+
+### Other
+- mark some crates 1.0 ([#789](https://github.com/mamba-org/rattler/pull/789))
+
 ## [0.22.16](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.15...rattler_lock-v0.22.16) - 2024-07-23
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.16"
+version = "0.22.17"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.26.3", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.26.4", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.0", default-features = false }
 file_url = { path = "../file_url", version = "0.1.3" }
 pep508_rs = { workspace = true, features = ["serde"] }

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.8](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.21.7...rattler_package_streaming-v0.21.8) - 2024-07-25
+
+### Other
+- mark some crates 1.0 ([#789](https://github.com/mamba-org/rattler/pull/789))
+
 ## [0.21.7](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.21.6...rattler_package_streaming-v0.21.7) - 2024-07-23
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.21.7"
+version = "0.21.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -15,7 +15,7 @@ bzip2 = { workspace = true }
 chrono = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.26.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.26.4", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.0", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.20.10", default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.4](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.21.3...rattler_repodata_gateway-v0.21.4) - 2024-07-25
+
+### Other
+- mark some crates 1.0 ([#789](https://github.com/mamba-org/rattler/pull/789))
+
 ## [0.21.3](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.21.2...rattler_repodata_gateway-v0.21.3) - 2024-07-23
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.3"
+version = "0.21.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -34,7 +34,7 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.26.3", default-features = false, optional = true }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.26.4", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "1.0.0", default-features = false, features = ["tokio", "serde"] }
 rattler_networking = { path = "../rattler_networking", version = "0.20.10", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
@@ -52,7 +52,7 @@ tokio-util = { workspace = true, features = ["codec", "io"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
-rattler_cache = { version = "0.1.4", path = "../rattler_cache" }
+rattler_cache = { version = "0.1.5", path = "../rattler_cache" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.4](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.21.3...rattler_shell-v0.21.4) - 2024-07-25
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.21.3](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.21.2...rattler_shell-v0.21.3) - 2024-07-23
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.21.3"
+version = "0.21.4"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.26.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.26.4", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path="../rattler_conda_types", version = "0.26.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.26.4", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.0", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.26.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.26.4", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `rattler`: 0.27.2 -> 0.27.3
* `rattler_cache`: 0.1.4 -> 0.1.5
* `rattler_conda_types`: 0.26.3 -> 0.26.4
* `rattler_package_streaming`: 0.21.7 -> 0.21.8
* `rattler_lock`: 0.22.16 -> 0.22.17
* `rattler_repodata_gateway`: 0.21.3 -> 0.21.4
* `rattler_index`: 0.19.21 -> 0.19.22
* `rattler_shell`: 0.21.3 -> 0.21.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler`
<blockquote>

## [0.27.3](https://github.com/mamba-org/rattler/compare/rattler-v0.27.2...rattler-v0.27.3) - 2024-07-25

### Other
- mark some crates 1.0 ([#789](https://github.com/mamba-org/rattler/pull/789))
</blockquote>

## `rattler_cache`
<blockquote>

## [0.1.5](https://github.com/mamba-org/rattler/compare/rattler_cache-v0.1.4...rattler_cache-v0.1.5) - 2024-07-25

### Other
- mark some crates 1.0 ([#789](https://github.com/mamba-org/rattler/pull/789))
</blockquote>

## `rattler_conda_types`
<blockquote>

## [0.26.4](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.26.3...rattler_conda_types-v0.26.4) - 2024-07-25

### Fixed
- url parsing for namelessmatchspec and cleanup functions ([#790](https://github.com/mamba-org/rattler/pull/790))

### Other
- mark some crates 1.0 ([#789](https://github.com/mamba-org/rattler/pull/789))
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.21.8](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.21.7...rattler_package_streaming-v0.21.8) - 2024-07-25

### Other
- mark some crates 1.0 ([#789](https://github.com/mamba-org/rattler/pull/789))
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.17](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.16...rattler_lock-v0.22.17) - 2024-07-25

### Other
- mark some crates 1.0 ([#789](https://github.com/mamba-org/rattler/pull/789))
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.21.4](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.21.3...rattler_repodata_gateway-v0.21.4) - 2024-07-25

### Other
- mark some crates 1.0 ([#789](https://github.com/mamba-org/rattler/pull/789))
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.22](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.21...rattler_index-v0.19.22) - 2024-07-25

### Other
- mark some crates 1.0 ([#789](https://github.com/mamba-org/rattler/pull/789))
</blockquote>

## `rattler_shell`
<blockquote>

## [0.21.4](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.21.3...rattler_shell-v0.21.4) - 2024-07-25

### Other
- updated the following local packages: rattler_conda_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).