### PR TITLE
fix: constraints on virtual packages were ignored

### DIFF
--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/repo_data/mod.rs
+assertion_line: 538
 expression: file_urls
 ---
 - channels/dummy/linux-64/issue_717-2.1-bla_1.tar.bz2
@@ -14,6 +15,7 @@ expression: file_urls
 - channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_2.conda
 - channels/dummy/linux-64/bors-1.0-bla_1.tar.bz2
 - channels/dummy/linux-64/bors-1.1-bla_1.tar.bz2
-- channels/dummy/linux-64/foobar-2.1-bla_1.tar.bz2
 - channels/dummy/linux-64/baz-2.0-unix_py36h1af98f8_2.tar.bz2
+- channels/dummy/linux-64/foobar-2.1-bla_1.tar.bz2
+- channels/dummy/linux-64/cuda-version-12.5-hd4f0392_3.conda
 - channels/dummy/linux-64/bors-2.0-bla_1.tar.bz2

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages-2.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages-2.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/repo_data/mod.rs
+assertion_line: 497
 expression: json
 ---
 {
@@ -123,6 +124,23 @@ expression: json
       "subdir": "linux-64",
       "timestamp": 1715610974,
       "version": "2.1"
+    },
+    "cuda-version-12.5-hd4f0392_3.conda": {
+      "build": "hd4f0392_3",
+      "build_number": 3,
+      "constrains": [
+        "__cuda >=12.1"
+      ],
+      "depends": [],
+      "license": "LicenseRef-NVIDIA-End-User-License-Agreement",
+      "license_family": "LicenseRef-NVIDIA-End-User-License-Agreement",
+      "md5": "6ae1a563a4aa61e55e8ae8260f0d021b",
+      "name": "cuda-version",
+      "sha256": "e45a5d14909296abd0784a073da9ee5c420fa58671fbc999f8a9ec898cf3486b",
+      "size": 21151,
+      "subdir": "noarch",
+      "timestamp": 1716314536803,
+      "version": "12.5"
     },
     "foo-3.0.2-py36h1af98f8_1.conda": {
       "build": "py36h1af98f8_1",

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/repo_data/mod.rs
+assertion_line: 493
 expression: repodata
 ---
 info:
@@ -112,6 +113,21 @@ packages:
     subdir: linux-64
     timestamp: 1715610974
     version: "2.1"
+  cuda-version-12.5-hd4f0392_3.conda:
+    build: hd4f0392_3
+    build_number: 3
+    constrains:
+      - __cuda >=12.1
+    depends: []
+    license: LicenseRef-NVIDIA-End-User-License-Agreement
+    license_family: LicenseRef-NVIDIA-End-User-License-Agreement
+    md5: 6ae1a563a4aa61e55e8ae8260f0d021b
+    name: cuda-version
+    sha256: e45a5d14909296abd0784a073da9ee5c420fa58671fbc999f8a9ec898cf3486b
+    size: 21151
+    subdir: noarch
+    timestamp: 1716314536803
+    version: "12.5"
   foo-3.0.2-py36h1af98f8_1.conda:
     build: py36h1af98f8_1
     build_number: 1

--- a/crates/rattler_solve/tests/snapshots/backends__libsolv_c__virtual_package_constrains.snap
+++ b/crates/rattler_solve/tests/snapshots/backends__libsolv_c__virtual_package_constrains.snap
@@ -1,0 +1,6 @@
+---
+source: crates/rattler_solve/tests/backends.rs
+assertion_line: 614
+expression: output
+---
+Cannot solve the request because of: package cuda-version-12.5-hd4f0392_3 has constraint __cuda >=12.1 conflicting with __cuda-1

--- a/crates/rattler_solve/tests/snapshots/backends__resolvo__virtual_package_constrains.snap
+++ b/crates/rattler_solve/tests/snapshots/backends__resolvo__virtual_package_constrains.snap
@@ -1,0 +1,11 @@
+---
+source: crates/rattler_solve/tests/backends.rs
+assertion_line: 711
+expression: output
+---
+Cannot solve the request because of: The following packages are incompatible
+├─ __cuda * can be installed with any of the following options:
+│  └─ __cuda 1
+└─ cuda-version * cannot be installed because there are no viable options:
+   └─ cuda-version 12.5 would constrain
+      └─ __cuda >=12.1 , which conflicts with any installable versions previously reported

--- a/test-data/channels/dummy/linux-64/repodata.json
+++ b/test-data/channels/dummy/linux-64/repodata.json
@@ -5,6 +5,21 @@
     "base_url": "../linux-64"
   },
   "packages": {
+    "cuda-version-12.5-hd4f0392_3.conda": {
+      "build": "hd4f0392_3",
+      "build_number": 3,
+      "depends": [],
+      "constrains": ["__cuda >=12.1"],
+      "license": "LicenseRef-NVIDIA-End-User-License-Agreement",
+      "license_family": "LicenseRef-NVIDIA-End-User-License-Agreement",
+      "md5": "6ae1a563a4aa61e55e8ae8260f0d021b",
+      "name": "cuda-version",
+      "sha256": "e45a5d14909296abd0784a073da9ee5c420fa58671fbc999f8a9ec898cf3486b",
+      "size": 21151,
+      "subdir": "noarch",
+      "timestamp": 1716314536803,
+      "version": "12.5"
+    },
     "foo-3.0.2-py36h1af98f8_1.tar.bz2": {
       "build": "py36h1af98f8_1",
       "build_number": 1,


### PR DESCRIPTION
If there was a package that had a constraint on a virtual package, e.g.:

```json
"constrains": ["__cuda >=12.1"],
```

and the virtual dependency was never explicitly required it was silently ignored. So even though your system would only support `cuda 11.8` the solver could select a version of a package that required a higher version. 

This PR solves this by adding explicit requirements on each specified virtual package. This behavior is also added for libsolv.