### PR TITLE
chore: add / for forward compatibility of the lockfile

### DIFF
--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -692,5 +692,9 @@ mod tests {
         let channel_with_backslash =
             Channel::from_str("https://conda.anaconda.org/conda-forge/", &channel_config).unwrap();
         assert_eq!(channel.base_url(), channel_with_backslash.base_url());
+        assert_eq!(
+            channel.base_url().as_str(),
+            "https://conda.anaconda.org/conda-forge/"
+        );
     }
 }

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -88,6 +88,7 @@ impl NamedChannelOrUrl {
     }
 
     /// Converts the channel to a base url using the given configuration.
+    /// This method ensures that the base url always ends with a `/`.
     pub fn into_base_url(self, config: &ChannelConfig) -> Url {
         match self {
             NamedChannelOrUrl::Name(name) => {
@@ -95,7 +96,7 @@ impl NamedChannelOrUrl {
                 if let Ok(mut segments) = base_url.path_segments_mut() {
                     segments.push(&name);
                 }
-                base_url
+                add_trailing_slash(&base_url).into_owned()
             }
             NamedChannelOrUrl::Url(url) => add_trailing_slash(&url).into_owned(),
         }
@@ -677,17 +678,27 @@ mod tests {
             channel_alias: Url::from_str("https://conda.anaconda.org").unwrap(),
             root_dir: std::env::current_dir().expect("No current dir set"),
         };
+
+        // Normal channel should have backslash
         let channel = Channel::from_str("conda-forge", &channel_config).unwrap();
         let channel_with_backslash =
             Channel::from_str("https://conda.anaconda.org/conda-forge/", &channel_config).unwrap();
         assert_eq!(channel.base_url(), channel_with_backslash.base_url());
 
+        // Channel with backslash should have backslash
         let channel_with_backslash = Channel::from_str("conda-forge/", &channel_config).unwrap();
         let channel =
             Channel::from_str("https://conda.anaconda.org/conda-forge", &channel_config).unwrap();
         assert_eq!(channel.base_url(), channel_with_backslash.base_url());
 
+        // The named channel should have backslash
         let named_channel = NamedChannelOrUrl::Name("conda-forge".to_string());
+        assert_eq!("https://conda.anaconda.org/conda-forge/", named_channel.clone().into_base_url(&channel_config).as_str());
+
+        let url_channel = NamedChannelOrUrl::Url(Url::from_str("https://conda.anaconda.org/conda-forge").unwrap());
+        assert_eq!("https://conda.anaconda.org/conda-forge/", url_channel.into_base_url(&channel_config).as_str());
+
+        // The named channel to channel should have backslash
         let channel = named_channel.into_channel(&channel_config);
         let channel_with_backslash =
             Channel::from_str("https://conda.anaconda.org/conda-forge/", &channel_config).unwrap();

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -693,10 +693,21 @@ mod tests {
 
         // The named channel should have backslash
         let named_channel = NamedChannelOrUrl::Name("conda-forge".to_string());
-        assert_eq!("https://conda.anaconda.org/conda-forge/", named_channel.clone().into_base_url(&channel_config).as_str());
+        assert_eq!(
+            "https://conda.anaconda.org/conda-forge/",
+            named_channel
+                .clone()
+                .into_base_url(&channel_config)
+                .as_str()
+        );
 
-        let url_channel = NamedChannelOrUrl::Url(Url::from_str("https://conda.anaconda.org/conda-forge").unwrap());
-        assert_eq!("https://conda.anaconda.org/conda-forge/", url_channel.into_base_url(&channel_config).as_str());
+        let url_channel = NamedChannelOrUrl::Url(
+            Url::from_str("https://conda.anaconda.org/conda-forge").unwrap(),
+        );
+        assert_eq!(
+            "https://conda.anaconda.org/conda-forge/",
+            url_channel.into_base_url(&channel_config).as_str()
+        );
 
         // The named channel to channel should have backslash
         let channel = named_channel.into_channel(&channel_config);

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -6,7 +6,6 @@ pub mod sharded;
 mod topological_sort;
 
 use std::{
-    borrow::Cow,
     collections::{BTreeMap, BTreeSet},
     fmt::{Display, Formatter},
     path::Path,
@@ -20,6 +19,7 @@ use serde_with::{serde_as, skip_serializing_none, OneOrMany};
 use thiserror::Error;
 use url::Url;
 
+use crate::utils::url::add_trailing_slash;
 use crate::{
     build_spec::BuildNumber,
     package::{IndexJson, RunExportsJson},
@@ -272,17 +272,6 @@ pub fn compute_package_url(
     absolute_url
         .join(filename)
         .expect("failed to join base_url and filename")
-}
-
-fn add_trailing_slash(url: &Url) -> Cow<'_, Url> {
-    let path = url.path();
-    if path.ends_with('/') {
-        Cow::Borrowed(url)
-    } else {
-        let mut url = url.clone();
-        url.set_path(&format!("{path}/"));
-        Cow::Owned(url)
-    }
 }
 
 impl PackageRecord {

--- a/crates/rattler_conda_types/src/utils/url.rs
+++ b/crates/rattler_conda_types/src/utils/url.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+use url::Url;
+
 /// Parses the schema part of the human-readable channel. Returns the scheme part if it exists.
 pub(crate) fn parse_scheme(channel: &str) -> Option<&str> {
     let scheme_end = channel.find("://")?;
@@ -20,5 +23,16 @@ pub(crate) fn parse_scheme(channel: &str) -> Option<&str> {
         Some(scheme_part)
     } else {
         None
+    }
+}
+
+pub(crate) fn add_trailing_slash(url: &Url) -> Cow<'_, Url> {
+    let path = url.path();
+    if path.ends_with('/') {
+        Cow::Borrowed(url)
+    } else {
+        let mut url = url.clone();
+        url.set_path(&format!("{path}/"));
+        Cow::Owned(url)
     }
 }


### PR DESCRIPTION
This should re-add the backslash to the channel.

This is to be forward compatible with the previous situation.