### PR TITLE
fix: parse `~=` as version not as path

### DIFF
--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -38,10 +38,11 @@ typed-path = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 indexmap = { workspace = true }
 rattler_redaction = { version = "0.1.0", path = "../rattler_redaction" }
+dirs = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
-insta = { workspace = true, features = ["yaml", "redactions", "toml", "glob"] }
+insta = { workspace = true, features = ["yaml", "redactions", "toml", "glob", "filters"] }
 rattler_package_streaming = { path = "../rattler_package_streaming", default-features = false, features = ["rustls-tls"] }
 tempfile = { workspace = true }
 rstest = { workspace = true }

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -449,14 +449,14 @@ fn absolute_path(path: &str, root_dir: &Path) -> Result<Utf8TypedPathBuf, ParseC
     }
 
     // Parse the `~` as the home folder
-    if path.starts_with("~/") {
+    if let Some(user_path) = path.strip_prefix("~/").ok().or_else(|| path.strip_prefix("~\\").ok()) {
         return Ok(Utf8TypedPathBuf::from(
             dirs::home_dir()
                 .ok_or(ParseChannelError::InvalidPath(path.to_string()))?
                 .to_string_lossy()
                 .as_ref(),
         )
-        .join(path.strip_prefix("~/").unwrap()));
+        .join(user_path);
     }
 
     let root_dir_str = root_dir

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -534,7 +534,7 @@ mod tests {
             .unwrap()
             .into_os_string()
             .into_encoded_bytes();
-        let home_dir = Utf8NativePath::from_bytes_path(&NativePath::new(&home_dir))
+        let home_dir = Utf8NativePath::from_bytes_path(NativePath::new(&home_dir))
             .unwrap()
             .to_typed_path();
         assert_eq!(

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -454,8 +454,7 @@ fn absolute_path(path: &str, root_dir: &Path) -> Result<Utf8TypedPathBuf, ParseC
     }
 
     // Parse the `~/` as the home folder
-    if let Ok(user_path) = path.strip_prefix("~/")
-    {
+    if let Ok(user_path) = path.strip_prefix("~/") {
         return Ok(Utf8TypedPathBuf::from(
             dirs::home_dir()
                 .ok_or(ParseChannelError::InvalidPath(path.to_string()))?
@@ -534,7 +533,10 @@ mod tests {
 
         let binding = dirs::home_dir().unwrap();
         let home_dir = binding.to_str().unwrap();
-        assert_eq!(absolute_path("~/unix_dir", &current_dir).unwrap().as_str(), format!("{home_dir}/unix_dir").as_str());
+        assert_eq!(
+            absolute_path("~/unix_dir", &current_dir).unwrap().as_str(),
+            format!("{home_dir}/unix_dir").as_str()
+        );
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -966,7 +966,7 @@ mod tests {
             // subdir in brackets take precedence
             "conda-forge/linux-32::python[version=3.9, subdir=linux-64]",
             "conda-forge/linux-32::python ==3.9[subdir=linux-64, build_number=\"0\"]",
-            "rust ~=1.2.3"
+            "rust ~=1.2.3",
         ];
 
         let evaluated: IndexMap<_, _> = specs

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -987,10 +987,13 @@ mod tests {
             })
             .collect();
 
-        // Strip absolute paths from the channels for testing
-        let path = Url::from_directory_path(dirs::home_dir().unwrap()).unwrap();
+        // Strip absolute paths to this crate from the channels for testing
+        let crate_root = env!("CARGO_MANIFEST_DIR");
+        let crate_path = Url::from_directory_path(std::path::Path::new(crate_root)).unwrap();
+        let home = Url::from_directory_path(dirs::home_dir().unwrap()).unwrap();
         insta::with_settings!({filters => vec![
-            (path.as_str(), "file://<ROOT>/"),
+            (home.as_str(), "file://<HOME>/"),
+            (crate_path.as_str(), "file://<CRATE>/"),
         ]}, {
             insta::assert_yaml_snapshot!(
             format!("test_from_string_{strictness:?}"),

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -992,8 +992,8 @@ mod tests {
         let crate_path = Url::from_directory_path(std::path::Path::new(crate_root)).unwrap();
         let home = Url::from_directory_path(dirs::home_dir().unwrap()).unwrap();
         insta::with_settings!({filters => vec![
-            (home.as_str(), "file://<HOME>/"),
             (crate_path.as_str(), "file://<CRATE>/"),
+            (home.as_str(), "file://<HOME>/"),
         ]}, {
             insta::assert_yaml_snapshot!(
             format!("test_from_string_{strictness:?}"),

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -968,6 +968,7 @@ mod tests {
             "conda-forge/linux-32::python ==3.9[subdir=linux-64, build_number=\"0\"]",
             "rust ~=1.2.3",
             "~/channel/dir::package",
+            "~\\windows_channel::package",
             "./relative/channel::package",
         ];
 

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -1204,40 +1204,33 @@ mod tests {
 
     #[test]
     fn test_parse_channel_subdir() {
-        let (channel, subdir) = parse_channel_and_subdir("conda-forge").unwrap();
-        assert_eq!(
-            channel.unwrap(),
-            Channel::from_str("conda-forge", &channel_config()).unwrap()
-        );
-        assert_eq!(subdir, None);
+        let test_cases = vec![
+            ("conda-forge", Some("conda-forge"), None),
+            (
+                "conda-forge/linux-64",
+                Some("conda-forge"),
+                Some("linux-64"),
+            ),
+            (
+                "conda-forge/label/test",
+                Some("conda-forge/label/test"),
+                None,
+            ),
+            (
+                "conda-forge/linux-64/label/test",
+                Some("conda-forge/linux-64/label/test"),
+                None,
+            ),
+            ("*/linux-64", Some("*"), Some("linux-64")),
+        ];
 
-        let (channel, subdir) = parse_channel_and_subdir("conda-forge/linux-64").unwrap();
-        assert_eq!(
-            channel.unwrap(),
-            Channel::from_str("conda-forge", &channel_config()).unwrap()
-        );
-        assert_eq!(subdir, Some("linux-64".to_string()));
-
-        let (channel, subdir) = parse_channel_and_subdir("conda-forge/label/test").unwrap();
-        assert_eq!(
-            channel.unwrap(),
-            Channel::from_str("conda-forge/label/test", &channel_config()).unwrap()
-        );
-        assert_eq!(subdir, None);
-
-        let (channel, subdir) =
-            parse_channel_and_subdir("conda-forge/linux-64/label/test").unwrap();
-        assert_eq!(
-            channel.unwrap(),
-            Channel::from_str("conda-forge/linux-64/label/test", &channel_config()).unwrap()
-        );
-        assert_eq!(subdir, None);
-
-        let (channel, subdir) = parse_channel_and_subdir("*/linux-64").unwrap();
-        assert_eq!(
-            channel.unwrap(),
-            Channel::from_str("*", &channel_config()).unwrap()
-        );
-        assert_eq!(subdir, Some("linux-64".to_string()));
+        for (input, expected_channel, expected_subdir) in test_cases {
+            let (channel, subdir) = parse_channel_and_subdir(input).unwrap();
+            assert_eq!(
+                channel.unwrap(),
+                Channel::from_str(expected_channel.unwrap(), &channel_config()).unwrap()
+            );
+            assert_eq!(subdir, expected_subdir.map(|s| s.to_string()));
+        }
     }
 }

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -966,6 +966,7 @@ mod tests {
             // subdir in brackets take precedence
             "conda-forge/linux-32::python[version=3.9, subdir=linux-64]",
             "conda-forge/linux-32::python ==3.9[subdir=linux-64, build_number=\"0\"]",
+            "rust ~=1.2.3"
         ];
 
         let evaluated: IndexMap<_, _> = specs
@@ -1001,6 +1002,28 @@ mod tests {
         let specs = [
             "2.7|>=3.6",
             "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2",
+            "~=1.2.3",
+            "*.* mkl",
+            "C:\\Users\\user\\conda-bld\\linux-64\\foo-1.0-py27_0.tar.bz2",
+            "=1.0=py27_0",
+            "==1.0=py27_0",
+            "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda",
+            "https://repo.prefix.dev/ruben-arts/linux-64/boost-cpp-1.78.0-h75c5d50_1.tar.bz2",
+            "3.8.* *_cpython",
+            "=*=cuda*",
+            ">=1!164.3095,<1!165",
+            "/home/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2",
+            "[version=1.0.*]",
+            "[version=1.0.*, build_number=\">6\"]",
+            "==2.7.*.*|>=3.6",
+            "3.9",
+            "*",
+            "[version=3.9]",
+            "[version=3.9]",
+            "[version=3.9, subdir=linux-64]",
+            // subdir in brackets take precedence
+            "[version=3.9, subdir=linux-64]",
+            "==3.9[subdir=linux-64, build_number=\"0\"]",
         ];
 
         let evaluated: IndexMap<_, _> = specs

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
@@ -98,3 +98,6 @@ python=*:
     base_url: "https://conda.anaconda.org/conda-forge/"
     name: conda-forge
   subdir: linux-64
+rust ~=1.2.3:
+  name: rust
+  version: ~=1.2.3

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
@@ -101,3 +101,13 @@ python=*:
 rust ~=1.2.3:
   name: rust
   version: ~=1.2.3
+"~/channel/dir::package":
+  name: package
+  channel:
+    base_url: "file://<ROOT>/channel/dir/"
+    name: ~/channel/dir
+"./relative/channel::package":
+  name: package
+  channel:
+    base_url: "file://<ROOT>/dev/rattler/crates/rattler_conda_types/relative/channel/"
+    name: "./relative/channel"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
@@ -106,6 +106,8 @@ rust ~=1.2.3:
   channel:
     base_url: "file://<ROOT>/channel/dir/"
     name: ~/channel/dir
+"~\\windows_channel::package":
+  error: invalid channel
 "./relative/channel::package":
   name: package
   channel:

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
@@ -111,5 +111,5 @@ rust ~=1.2.3:
 "./relative/channel::package":
   name: package
   channel:
-    base_url: "file://<HOME>/dev/rattler/crates/rattler_conda_types/relative/channel/"
+    base_url: "file://<CRATE>/relative/channel/"
     name: "./relative/channel"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
@@ -104,12 +104,12 @@ rust ~=1.2.3:
 "~/channel/dir::package":
   name: package
   channel:
-    base_url: "file://<ROOT>/channel/dir/"
+    base_url: "file://<HOME>/channel/dir/"
     name: ~/channel/dir
 "~\\windows_channel::package":
   error: invalid channel
 "./relative/channel::package":
   name: package
   channel:
-    base_url: "file://<ROOT>/dev/rattler/crates/rattler_conda_types/relative/channel/"
+    base_url: "file://<HOME>/dev/rattler/crates/rattler_conda_types/relative/channel/"
     name: "./relative/channel"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -98,6 +98,8 @@ rust ~=1.2.3:
   channel:
     base_url: "file://<ROOT>/channel/dir/"
     name: ~/channel/dir
+"~\\windows_channel::package":
+  error: invalid channel
 "./relative/channel::package":
   name: package
   channel:

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -93,3 +93,13 @@ python=*:
 rust ~=1.2.3:
   name: rust
   version: ~=1.2.3
+"~/channel/dir::package":
+  name: package
+  channel:
+    base_url: "file://<ROOT>/channel/dir/"
+    name: ~/channel/dir
+"./relative/channel::package":
+  name: package
+  channel:
+    base_url: "file://<ROOT>/dev/rattler/crates/rattler_conda_types/relative/channel/"
+    name: "./relative/channel"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -103,5 +103,5 @@ rust ~=1.2.3:
 "./relative/channel::package":
   name: package
   channel:
-    base_url: "file://<HOME>/dev/rattler/crates/rattler_conda_types/relative/channel/"
+    base_url: "file://<CRATE>/relative/channel/"
     name: "./relative/channel"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -90,3 +90,6 @@ python=*:
     base_url: "https://conda.anaconda.org/conda-forge/"
     name: conda-forge
   subdir: linux-64
+rust ~=1.2.3:
+  name: rust
+  version: ~=1.2.3

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -96,12 +96,12 @@ rust ~=1.2.3:
 "~/channel/dir::package":
   name: package
   channel:
-    base_url: "file://<ROOT>/channel/dir/"
+    base_url: "file://<HOME>/channel/dir/"
     name: ~/channel/dir
 "~\\windows_channel::package":
   error: invalid channel
 "./relative/channel::package":
   name: package
   channel:
-    base_url: "file://<ROOT>/dev/rattler/crates/rattler_conda_types/relative/channel/"
+    base_url: "file://<HOME>/dev/rattler/crates/rattler_conda_types/relative/channel/"
     name: "./relative/channel"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Lenient.snap
@@ -6,3 +6,54 @@ expression: evaluated
   version: "==2.7|>=3.6"
 "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2":
   url: "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2"
+~=1.2.3:
+  version: ~=1.2.3
+"*.* mkl":
+  version: "*"
+  build: mkl
+"C:\\Users\\user\\conda-bld\\linux-64\\foo-1.0-py27_0.tar.bz2":
+  url: "file:///C:/Users/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2"
+"=1.0=py27_0":
+  version: "==1.0"
+  build: py27_0
+"==1.0=py27_0":
+  version: "==1.0"
+  build: py27_0
+"https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda":
+  url: "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda"
+"https://repo.prefix.dev/ruben-arts/linux-64/boost-cpp-1.78.0-h75c5d50_1.tar.bz2":
+  url: "https://repo.prefix.dev/ruben-arts/linux-64/boost-cpp-1.78.0-h75c5d50_1.tar.bz2"
+3.8.* *_cpython:
+  version: 3.8.*
+  build: "*_cpython"
+"=*=cuda*":
+  version: "*"
+  build: cuda*
+">=1!164.3095,<1!165":
+  version: ">=1!164.3095,<1!165"
+/home/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2:
+  url: "file:///home/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2"
+"[version=1.0.*]":
+  version: 1.0.*
+"[version=1.0.*, build_number=\">6\"]":
+  version: 1.0.*
+  build_number:
+    op: Gt
+    rhs: 6
+"==2.7.*.*|>=3.6":
+  version: 2.7.*|>=3.6
+"3.9":
+  version: "==3.9"
+"*":
+  version: "*"
+"[version=3.9]":
+  version: "==3.9"
+"[version=3.9, subdir=linux-64]":
+  version: "==3.9"
+  subdir: linux-64
+"==3.9[subdir=linux-64, build_number=\"0\"]":
+  version: "==3.9"
+  build_number:
+    op: Eq
+    rhs: 0
+  subdir: linux-64

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
@@ -6,3 +6,51 @@ expression: evaluated
   version: "==2.7|>=3.6"
 "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2":
   url: "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2"
+~=1.2.3:
+  version: ~=1.2.3
+"*.* mkl":
+  version: "*"
+  build: mkl
+"C:\\Users\\user\\conda-bld\\linux-64\\foo-1.0-py27_0.tar.bz2":
+  url: "file:///C:/Users/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2"
+"=1.0=py27_0":
+  error: "The build string '=py27_0' is not valid, it can only contain alphanumeric characters and underscores"
+"==1.0=py27_0":
+  error: "The build string '=py27_0' is not valid, it can only contain alphanumeric characters and underscores"
+"https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda":
+  url: "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda"
+"https://repo.prefix.dev/ruben-arts/linux-64/boost-cpp-1.78.0-h75c5d50_1.tar.bz2":
+  url: "https://repo.prefix.dev/ruben-arts/linux-64/boost-cpp-1.78.0-h75c5d50_1.tar.bz2"
+3.8.* *_cpython:
+  version: 3.8.*
+  build: "*_cpython"
+"=*=cuda*":
+  error: "The build string '=cuda*' is not valid, it can only contain alphanumeric characters and underscores"
+">=1!164.3095,<1!165":
+  version: ">=1!164.3095,<1!165"
+/home/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2:
+  url: "file:///home/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2"
+"[version=1.0.*]":
+  version: 1.0.*
+"[version=1.0.*, build_number=\">6\"]":
+  version: 1.0.*
+  build_number:
+    op: Gt
+    rhs: 6
+"==2.7.*.*|>=3.6":
+  error: "invalid version constraint: regex constraints are not supported"
+"3.9":
+  version: "==3.9"
+"*":
+  version: "*"
+"[version=3.9]":
+  version: "==3.9"
+"[version=3.9, subdir=linux-64]":
+  version: "==3.9"
+  subdir: linux-64
+"==3.9[subdir=linux-64, build_number=\"0\"]":
+  version: "==3.9"
+  build_number:
+    op: Eq
+    rhs: 0
+  subdir: linux-64

--- a/crates/rattler_conda_types/src/utils/path.rs
+++ b/crates/rattler_conda_types/src/utils/path.rs
@@ -39,8 +39,6 @@ pub(crate) fn is_path(path: &str) -> bool {
 }
 
 mod tests {
-    use super::*;
-
     #[test]
     fn test_is_absolute_path() {
         assert!(is_absolute_path("/foo"));

--- a/crates/rattler_conda_types/src/utils/path.rs
+++ b/crates/rattler_conda_types/src/utils/path.rs
@@ -65,6 +65,7 @@ mod tests {
 
         assert!(is_path("./conda-forge/label/rust_dev"));
         assert!(is_path("~/foo"));
+        assert!(is_path("~\\foo"));
         assert!(is_path("./foo"));
         assert!(is_path("../foo"));
     }

--- a/crates/rattler_conda_types/src/utils/path.rs
+++ b/crates/rattler_conda_types/src/utils/path.rs
@@ -9,7 +9,7 @@ pub(crate) fn is_path(path: &str) -> bool {
     // Check if the path starts with a common path prefix
     if path.starts_with("./")
         || path.starts_with("..")
-        || path.starts_with('~') && !path.starts_with("~=")
+        || path.starts_with("~/")
         || path.starts_with('/')
         || path.starts_with("\\\\")
         || path.starts_with("//")

--- a/crates/rattler_conda_types/src/utils/path.rs
+++ b/crates/rattler_conda_types/src/utils/path.rs
@@ -1,5 +1,21 @@
 use itertools::Itertools;
 
+/// Returns true if the specified string is considered to be an absolute path
+pub(crate) fn is_absolute_path(path: &str) -> bool {
+    if path.contains("://") {
+        return false;
+    }
+
+    // Check if the path starts with a common absolute path prefix
+    if path.starts_with('/') || path.starts_with("\\\\") {
+        return true;
+    }
+
+    // A drive letter followed by a colon and a (backward or forward) slash
+    matches!(path.chars().take(3).collect_tuple(),
+        Some((letter, ':', '/' | '\\')) if letter.is_alphabetic())
+}
+
 /// Returns true if the specified string is considered to be a path
 pub(crate) fn is_path(path: &str) -> bool {
     if path.contains("://") {
@@ -20,4 +36,37 @@ pub(crate) fn is_path(path: &str) -> bool {
     // A drive letter followed by a colon and a (backward or forward) slash
     matches!(path.chars().take(3).collect_tuple(),
         Some((letter, ':', '/' | '\\')) if letter.is_alphabetic())
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_absolute_path() {
+        assert!(is_absolute_path("/foo"));
+        assert!(is_absolute_path("/C:/foo"));
+        assert!(is_absolute_path("C:/foo"));
+        assert!(is_absolute_path("\\\\foo"));
+        assert!(is_absolute_path("\\\\server\\foo"));
+
+        assert!(!is_absolute_path("conda-forge/label/rust_dev"));
+        assert!(!is_absolute_path("~/foo"));
+        assert!(!is_absolute_path("./foo"));
+        assert!(!is_absolute_path("../foo"));
+        assert!(!is_absolute_path("foo"));
+    }
+
+    #[test]
+    fn test_is_path() {
+        assert!(is_path("/foo"));
+        assert!(is_path("/C:/foo"));
+        assert!(is_path("C:/foo"));
+        assert!(is_path("\\\\foo"));
+        assert!(is_path("\\\\server\\foo"));
+
+        assert!(is_path("./conda-forge/label/rust_dev"));
+        assert!(is_path("~/foo"));
+        assert!(is_path("./foo"));
+        assert!(is_path("../foo"));
+    }
 }

--- a/crates/rattler_conda_types/src/utils/path.rs
+++ b/crates/rattler_conda_types/src/utils/path.rs
@@ -9,7 +9,7 @@ pub(crate) fn is_path(path: &str) -> bool {
     // Check if the path starts with a common path prefix
     if path.starts_with("./")
         || path.starts_with("..")
-        || path.starts_with('~')
+        || path.starts_with('~') && !path.starts_with("~=")
         || path.starts_with('/')
         || path.starts_with("\\\\")
         || path.starts_with("//")

--- a/crates/rattler_conda_types/src/utils/path.rs
+++ b/crates/rattler_conda_types/src/utils/path.rs
@@ -50,6 +50,7 @@ mod tests {
 
         assert!(!is_absolute_path("conda-forge/label/rust_dev"));
         assert!(!is_absolute_path("~/foo"));
+        assert!(!is_absolute_path("~\\foo"));
         assert!(!is_absolute_path("./foo"));
         assert!(!is_absolute_path("../foo"));
         assert!(!is_absolute_path("foo"));

--- a/crates/rattler_conda_types/src/utils/path.rs
+++ b/crates/rattler_conda_types/src/utils/path.rs
@@ -26,6 +26,7 @@ pub(crate) fn is_path(path: &str) -> bool {
     if path.starts_with("./")
         || path.starts_with("..")
         || path.starts_with("~/")
+        || path.starts_with("~\\")
         || path.starts_with('/')
         || path.starts_with("\\\\")
         || path.starts_with("//")

--- a/crates/rattler_conda_types/src/utils/path.rs
+++ b/crates/rattler_conda_types/src/utils/path.rs
@@ -26,7 +26,6 @@ pub(crate) fn is_path(path: &str) -> bool {
     if path.starts_with("./")
         || path.starts_with("..")
         || path.starts_with("~/")
-        || path.starts_with("~\\")
         || path.starts_with('/')
         || path.starts_with("\\\\")
         || path.starts_with("//")
@@ -42,6 +41,7 @@ pub(crate) fn is_path(path: &str) -> bool {
 mod tests {
     #[test]
     fn test_is_absolute_path() {
+        use super::is_absolute_path;
         assert!(is_absolute_path("/foo"));
         assert!(is_absolute_path("/C:/foo"));
         assert!(is_absolute_path("C:/foo"));
@@ -50,14 +50,15 @@ mod tests {
 
         assert!(!is_absolute_path("conda-forge/label/rust_dev"));
         assert!(!is_absolute_path("~/foo"));
-        assert!(!is_absolute_path("~\\foo"));
         assert!(!is_absolute_path("./foo"));
         assert!(!is_absolute_path("../foo"));
         assert!(!is_absolute_path("foo"));
+        assert!(!is_absolute_path("~\\foo"));
     }
 
     #[test]
     fn test_is_path() {
+        use super::is_path;
         assert!(is_path("/foo"));
         assert!(is_path("/C:/foo"));
         assert!(is_path("C:/foo"));
@@ -66,8 +67,9 @@ mod tests {
 
         assert!(is_path("./conda-forge/label/rust_dev"));
         assert!(is_path("~/foo"));
-        assert!(is_path("~\\foo"));
         assert!(is_path("./foo"));
         assert!(is_path("../foo"));
+
+        assert!(!is_path("~\\foo"));
     }
 }

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -2744,6 +2744,7 @@ name = "rattler_conda_types"
 version = "0.27.0"
 dependencies = [
  "chrono",
+ "dirs",
  "file_url",
  "fxhash",
  "glob",


### PR DESCRIPTION
By adding the path parsing to the nameless matchspec I broke the parsing of `~= 1.2.3`. 

This PR changes a few things to better deal with that. 
- It now checks for `~/` to verify if it is a path
- We can now parse `~/channel_name::package` as the tilde is now actually parsed instead of seen as part of the string.
- Added a bunch more test cases to catch more issues in the future. 